### PR TITLE
Fix osu!direct needing "-" in place of spaces

### DIFF
--- a/ruri/Aria.h
+++ b/ruri/Aria.h
@@ -1915,9 +1915,15 @@ void HandleAria(_Con s){
 
 		if (Start){
 			DontCloseConnection = 1;
-
+			std::string directQuery = std::string(res.Host.begin() + Start, res.Host.end());
+			for (int i = 0; i < directQuery.size(); i++) {
+				if (directQuery[i] == '+') {
+					directQuery[i] = '-';
+				}
+			}
+			
 			MIRROR::MirrorAPILock.lock();
-			MIRROR::MirrorAPIQue.emplace_back("api/search?" + std::string(res.Host.begin() + Start, res.Host.end()),s);
+			MIRROR::MirrorAPIQue.emplace_back("api/search?" + directQuery, s);
 			MIRROR::MirrorAPILock.unlock();
 		}
 	}


### PR DESCRIPTION
While playing on akatsuki and on my local server I noticed that you couldn't use spaces, see:
![screenshot032](https://user-images.githubusercontent.com/42550681/64471063-4f4df080-d144-11e9-9277-f315a1d7fdc3.jpg)
and instead you needed a "-", see:
![image](https://user-images.githubusercontent.com/42550681/64471072-5f65d000-d144-11e9-9eb6-eb16a8696b8b.png)

This fixes the issue
![screenshot041](https://user-images.githubusercontent.com/42550681/64471078-6ee51900-d144-11e9-9eae-feb48fd7c50e.jpg)
